### PR TITLE
Add Qwen tokenizer setup and update vocab registration.

### DIFF
--- a/setup/setup_assets.py
+++ b/setup/setup_assets.py
@@ -108,7 +108,7 @@ def reorganize_gemma_models(models_dir: str):
         shutil.move(str(src), str(dest))
 
     # tokenizer.model should stay at parent level for vocab loading
-    print(f"  [OK] Moved checkpoint files to 0/")
+    print("  [OK] Moved checkpoint files to 0/")
 
 
 def setup_gemma_vocabs(models_dir: str, vocabs_dir: str):
@@ -139,6 +139,37 @@ def setup_gemma_vocabs(models_dir: str, vocabs_dir: str):
       print(f"  [OK] Copied tokenizer from {model_dir}")
 
 
+def setup_qwen_vocabs(models_dir: str, vocabs_dir: str):
+  """Copy Qwen tokenizer files to vocabs directory.
+
+  Simply expects tokenizers in ~/.cache/simply/vocabs/
+  """
+  import shutil
+
+  dest_dir = Path(vocabs_dir) / 'Qwen3'
+  dest_dir.mkdir(parents=True, exist_ok=True)
+
+  # Source directory in models
+  # Assuming the model is downloaded as Qwen3-0.6B
+  src_dir = Path(models_dir) / 'Qwen3-0.6B'
+
+  if not src_dir.exists():
+    print(f"  [WARNING] Qwen source directory not found: {src_dir}")
+    return
+
+  files_to_copy = ['tokenizer.json', 'tokenizer_config.json']
+  for filename in files_to_copy:
+    src = src_dir / filename
+    dest = dest_dir / filename
+
+    if src.exists() and not dest.exists():
+      shutil.copy(str(src), str(dest))
+      print(f"  [OK] Copied {filename} to {dest_dir}")
+    elif not src.exists():
+        print(f"  [WARNING] Could not find {filename} in {src_dir}")
+
+
+
 def download_models(models_dir: str, repo: str = MODELS_REPO):
   """Download pretrained models from HuggingFace."""
   print(f"Downloading models from {repo}...")
@@ -162,6 +193,7 @@ def download_models(models_dir: str, repo: str = MODELS_REPO):
     # Setup vocab files
     print("\nSetting up vocab files...")
     setup_gemma_vocabs(models_dir, VOCABS_DIR)
+    setup_qwen_vocabs(models_dir, VOCABS_DIR)
 
     return True
   except Exception as e:

--- a/simply/data_lib.py
+++ b/simply/data_lib.py
@@ -18,7 +18,7 @@ import dataclasses
 import functools
 import json
 import os
-from typing import Callable, ClassVar, Mapping, MutableMapping, Optional, Protocol, Union
+from typing import Callable, ClassVar, Mapping, MutableMapping, Protocol, Union
 
 import einops
 from etils import epath
@@ -54,6 +54,7 @@ OPENMIX_V3_100864_V1_VOCAB = os.path.join(VOCABS_DIR, 'spm-100864-openmix_v3-r10
 OPENMIX_V3_100864_V2_VOCAB = os.path.join(VOCABS_DIR, 'spm-100864-openmix_v3-r100-v2-08312024.model')
 GEMMA2_VOCAB = os.path.join(VOCABS_DIR, 'gemma2_tokenizer.model')
 GEMMA3_VOCAB = os.path.join(VOCABS_DIR, 'gemma3_cleaned_262144_v2.spiece.model')
+QWEN3_VOCAB = os.path.join(VOCABS_DIR, 'Qwen3')
 
 OPENMIX_V1_VOCABS = [
     ('vb100864_openmix_v1', OPENMIX_V1_100864_VOCAB),
@@ -80,6 +81,10 @@ register_vocabs()
 
 tokenization.TokenizerRegistry.register_value(
     seqio.SentencePieceVocabulary(GEMMA3_VOCAB), name='vb262144_gemma3'
+)
+
+tokenization.TokenizerRegistry.register_value(
+    tokenization.HuggingFaceVocab(QWEN3_VOCAB), name='Qwen3'
 )
 
 PILE_50432_V1_VOCAB = os.path.join(VOCABS_DIR, 'spm-50432-pile-train00-02122024.model')


### PR DESCRIPTION
This PR adds support for the Qwen3 tokenizer by:
- Implementing `setup_qwen_vocabs` in `setup/setup_assets.py` to copy `tokenizer.json` and `tokenizer_config.json` to the vocabulary directory.
- Registering the `Qwen3` vocabulary in `simply/data_lib.py` using `tokenization.HuggingFaceVocab`.
- Ensuring the tokenizer setup is called during model download.

File Structure:
```
$ tree $SIMPLY_VOCABS
/scratch/qmei_root/qmei/jimmyzxj/simply_vocabs
├── gemma2_tokenizer.model
└── Qwen3
    ├── tokenizer_config.json
    └── tokenizer.json
```