### PR TITLE
Support GKE

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,27 @@ export JAX_DISABLE_JIT=True; EXP=simply_local_test_1; rm -rf /tmp/${EXP}; python
 #### Running on Google Cloud TPUs
 See the [GCloud Quickstart](gcloud_quickstart.md) to run your first experiment on a Cloud TPU, or the [full GCloud guide](docs/gcloud.md) for multi-host training, preemption handling, and monitoring.
 
+#### Running on GKE with XPK
+For GKE clusters with TPU node pools, use the provided launch script:
+
+```bash
+# Build the base Docker image
+docker build -f scripts/Dockerfile.simply -t gcr.io/$PROJECT/simply-jax-tpu:latest .
+docker push gcr.io/$PROJECT/simply-jax-tpu:latest
+
+# Launch a training workload
+./scripts/launch_gke.sh --config qwen3_0p6b \
+    --project my-project --cluster my-cluster \
+    --tpu-type v4-8 --image gcr.io/$PROJECT/simply-jax-tpu:latest
+
+# Manage workloads
+./scripts/launch_gke.sh --list        # list workloads
+./scripts/launch_gke.sh --logs NAME   # stream logs
+./scripts/launch_gke.sh --delete NAME # delete a workload
+```
+
+See the [GKE section in the full GCloud guide](docs/gcloud.md#11-running-on-gke-with-xpk) for details.
+
 #### Automated AI research with agents
 
 You can use agents like [Google Antigravity](https://antigravity.google/), [Claude Code](https://docs.anthropic.com/en/docs/claude-code), or [Gemini CLI](https://github.com/google-gemini/gemini-cli) to run automated research experiments. For example, paste the following prompt into your agent from the repo root to have it design and benchmark new optimizers on a toy setting:

--- a/README.md
+++ b/README.md
@@ -25,25 +25,7 @@ export JAX_DISABLE_JIT=True; EXP=simply_local_test_1; rm -rf /tmp/${EXP}; python
 See the [GCloud Quickstart](gcloud_quickstart.md) to run your first experiment on a Cloud TPU, or the [full GCloud guide](docs/gcloud.md) for multi-host training, preemption handling, and monitoring.
 
 #### Running on GKE with XPK
-For GKE clusters with TPU node pools, use the provided launch script:
-
-```bash
-# Build the base Docker image
-docker build -f scripts/Dockerfile.simply -t gcr.io/$PROJECT/simply-jax-tpu:latest .
-docker push gcr.io/$PROJECT/simply-jax-tpu:latest
-
-# Launch a training workload
-./scripts/launch_gke.sh --config qwen3_0p6b \
-    --project my-project --cluster my-cluster \
-    --tpu-type v4-8 --image gcr.io/$PROJECT/simply-jax-tpu:latest
-
-# Manage workloads
-./scripts/launch_gke.sh --list        # list workloads
-./scripts/launch_gke.sh --logs NAME   # stream logs
-./scripts/launch_gke.sh --delete NAME # delete a workload
-```
-
-See the [GKE section in the full GCloud guide](docs/gcloud.md#11-running-on-gke-with-xpk) for details.
+Google Kubernetes Engine (GKE) is supported. See [GKE quick start](gcloud_quickstart.md#optional-running-on-gke-with-xpk) to run your first experiment on GKE, and [GKE section in the full GCloud guide](docs/gcloud.md#11-running-on-gke-with-xpk) for details.
 
 #### Automated AI research with agents
 

--- a/docs/gcloud.md
+++ b/docs/gcloud.md
@@ -614,6 +614,160 @@ gcloud compute instances delete bastion \
 The GCS bucket, VPC, NAT, and firewall rules persist across
 experiments and don't need to be recreated.
 
+## 11. Running on GKE with XPK
+
+As an alternative to managing TPU VMs directly, you can run Simply
+on GKE (Google Kubernetes Engine) clusters with TPU node pools using
+[XPK](https://github.com/google/xpk). XPK handles Docker image
+building, job scheduling, and multi-host coordination automatically.
+
+### Prerequisites
+
+- A GKE cluster with TPU node pools (created via `xpk cluster
+  create` or manually)
+- [XPK](https://github.com/google/xpk) installed (`pip install xpk`)
+- Docker installed and accessible
+- `kubectl` configured to access your cluster
+
+### Building the Docker Image
+
+Simply provides a Dockerfile at `scripts/Dockerfile.simply` that
+pre-installs JAX with TPU support and all Simply dependencies:
+
+```bash
+# Build the image
+docker build -f scripts/Dockerfile.simply \
+    -t gcr.io/$PROJECT/simply-jax-tpu:latest .
+
+# Push to your project's container registry
+docker push gcr.io/$PROJECT/simply-jax-tpu:latest
+```
+
+The Dockerfile installs dependencies in a separate layer for fast
+rebuilds. When the workload starts, the launch script runs
+`pip install .` inside the container to install Simply itself from
+the source tree copied by XPK.
+
+### Launching a Workload
+
+Use `scripts/launch_gke.sh` to submit training jobs:
+
+```bash
+./scripts/launch_gke.sh --config qwen3_0p6b \
+    --project my-project \
+    --cluster my-cluster \
+    --zone us-central1 \
+    --tpu-type v4-8 \
+    --image gcr.io/my-project/simply-jax-tpu:latest
+```
+
+The script builds a Docker image (overlaying the Simply source onto
+the base image), pushes it, and submits the workload via
+`xpk workload create`. XPK uses its `--script-dir` flag to copy the
+Simply repo into the container's working directory.
+
+#### Required Flags
+
+| Flag | Env Variable | Description |
+|------|-------------|-------------|
+| `--config CONFIG` | | Simply experiment config name |
+| `--project PROJECT` | `SIMPLY_XPK_PROJECT` | GCP project ID |
+| `--cluster CLUSTER` | `SIMPLY_XPK_CLUSTER` | GKE cluster name |
+| `--image IMAGE` | `SIMPLY_XPK_IMAGE` | Base Docker image |
+
+#### Common Options
+
+| Flag | Env Variable | Default | Description |
+|------|-------------|---------|-------------|
+| `--zone ZONE` | `SIMPLY_XPK_ZONE` | `us-central1` | GCP zone/region |
+| `--tpu-type TYPE` | `SIMPLY_XPK_TPU_TYPE` | `v4-8` | TPU accelerator type |
+| `--num-slices N` | `SIMPLY_XPK_NUM_SLICES` | `1` | Number of TPU slices |
+| `--priority PRI` | `SIMPLY_XPK_PRIORITY` | `medium` | Workload priority |
+| `--name NAME` | | auto | Custom workload name |
+| `--spot` | | (default) | Use spot/preemptible instances |
+| `--on-demand` | | | Use on-demand instances |
+| `--dry-run` | | | Print the xpk command without running |
+
+#### Passing Simply Arguments
+
+Pass additional flags to `simply.main` after `--`:
+
+```bash
+./scripts/launch_gke.sh --config lm_test \
+    --project my-project --cluster my-cluster \
+    --image gcr.io/my-project/simply-jax-tpu:latest \
+    -- --mesh_shape 1,4,32 --experiment_dir gs://my-bucket/exp1
+```
+
+### Using Environment Variables
+
+To avoid repeating flags, set environment variables in your shell
+profile:
+
+```bash
+export SIMPLY_XPK_PROJECT=my-project
+export SIMPLY_XPK_CLUSTER=my-cluster
+export SIMPLY_XPK_ZONE=us-central1
+export SIMPLY_XPK_IMAGE=gcr.io/my-project/simply-jax-tpu:latest
+
+# Now just specify the config:
+./scripts/launch_gke.sh --config qwen3_0p6b --tpu-type v4-8
+```
+
+### Profiling with XProf
+
+To collect XProf traces, pass `--profile` and set a GCS bucket for
+trace storage:
+
+```bash
+export SIMPLY_XPK_GCS_BUCKET=gs://my-bucket/profiles
+
+./scripts/launch_gke.sh --config qwen3_0p6b --profile \
+    --project my-project --cluster my-cluster \
+    --image gcr.io/my-project/simply-jax-tpu:latest
+```
+
+This sets `JAX_PROFILER_LOG_DIR` inside the container and saves
+worker logs to the GCS bucket. By default, profiling starts after
+5 warmup steps and captures 3 steps (configurable via
+`--profile-warmup` and `--profile-steps`).
+
+### Managing Workloads
+
+List, monitor, and delete workloads:
+
+```bash
+# List all simply-* workloads on the cluster
+./scripts/launch_gke.sh --list
+
+# Stream logs from a running workload
+./scripts/launch_gke.sh --logs simply-qwen3-0p6b-0310
+
+# Delete a workload
+./scripts/launch_gke.sh --delete simply-qwen3-0p6b-0310
+```
+
+You can also use `kubectl` directly for more detailed inspection:
+
+```bash
+# View logs from a specific worker
+kubectl logs -l jobset.sigs.k8s.io/jobset-name=simply-qwen3-0p6b-0310 \
+    --all-containers --tail=100
+
+# Check pod status
+kubectl get pods -l jobset.sigs.k8s.io/jobset-name=simply-qwen3-0p6b-0310
+```
+
+### Docker Access
+
+The launch script checks for Docker access and falls back to
+`sg docker` if the current user isn't in the docker group. If
+Docker is not accessible at all, run:
+
+```bash
+sudo usermod -aG docker $USER && newgrp docker
+```
+
 ## Future Work
 
 - **GPU VMs** -- A100/H100 setup

--- a/docs/gcloud.md
+++ b/docs/gcloud.md
@@ -614,20 +614,36 @@ gcloud compute instances delete bastion \
 The GCS bucket, VPC, NAT, and firewall rules persist across
 experiments and don't need to be recreated.
 
-## 11. Running on GKE with XPK
+## Running on GKE with XPK
 
 As an alternative to managing TPU VMs directly, you can run Simply
 on GKE (Google Kubernetes Engine) clusters with TPU node pools using
-[XPK](https://github.com/google/xpk). XPK handles Docker image
-building, job scheduling, and multi-host coordination automatically.
+[XPK](https://github.com/AI-Hypercomputer/xpk). XPK handles Docker
+image building, job scheduling, and multi-host coordination
+automatically.
 
 ### Prerequisites
 
-- A GKE cluster with TPU node pools (created via `xpk cluster
-  create` or manually)
-- [XPK](https://github.com/google/xpk) installed (`pip install xpk`)
-- Docker installed and accessible
-- `kubectl` configured to access your cluster
+- A GKE cluster with a TPU node pool already provisioned
+- [XPK](https://github.com/AI-Hypercomputer/xpk) installed
+  (`pip install xpk`)
+- Docker installed and authenticated to push to GCR/Artifact
+  Registry
+- `kubectl` configured for your cluster
+  (`gcloud container clusters get-credentials ...`)
+
+### Setting Environment Variables
+
+Set these once per shell session (or in your shell profile).
+Replace the values with your own project, cluster, and bucket:
+
+```bash
+export PROJECT=your-gcp-project-id
+export CLUSTER=your-gke-cluster-name
+export ZONE=us-central1
+export TPUTYPE=v4-8
+export BUCKET=your-gcs-bucket-name
+```
 
 ### Building the Docker Image
 
@@ -635,6 +651,8 @@ Simply provides a Dockerfile at `scripts/Dockerfile.simply` that
 pre-installs JAX with TPU support and all Simply dependencies:
 
 ```bash
+cd /path/to/simply
+
 # Build the image
 docker build -f scripts/Dockerfile.simply \
     -t gcr.io/$PROJECT/simply-jax-tpu:latest .
@@ -645,74 +663,39 @@ docker push gcr.io/$PROJECT/simply-jax-tpu:latest
 
 The Dockerfile installs dependencies in a separate layer for fast
 rebuilds. When the workload starts, the launch script runs
-`pip install .` inside the container to install Simply itself from
-the source tree copied by XPK.
+`uv pip install --system .` inside the container to install Simply
+itself from the source tree copied by XPK's `--script-dir` flag.
 
-### Launching a Workload
+### Launching a Workload with a Registered Config
 
-Use `scripts/launch_gke.sh` to submit training jobs:
+The simplest way to launch is with a registered config name. The
+`lm_test_gke_training` config is designed for GKE testing -- it
+uses a small model with no checkpoint loading:
 
 ```bash
-./scripts/launch_gke.sh --config qwen3_0p6b \
-    --project my-project \
-    --cluster my-cluster \
-    --zone us-central1 \
-    --tpu-type v4-8 \
-    --image gcr.io/my-project/simply-jax-tpu:latest
+./scripts/launch_gke.sh \
+    --config lm_test_gke_training \
+    --project $PROJECT \
+    --cluster $CLUSTER \
+    --zone $ZONE \
+    --tpu-type $TPUTYPE \
+    --image gcr.io/$PROJECT/simply-jax-tpu:latest
 ```
 
-The script builds a Docker image (overlaying the Simply source onto
-the base image), pushes it, and submits the workload via
-`xpk workload create`. XPK uses its `--script-dir` flag to copy the
-Simply repo into the container's working directory.
-
-#### Required Flags
-
-| Flag | Env Variable | Description |
-|------|-------------|-------------|
-| `--config CONFIG` | | Simply experiment config name |
-| `--project PROJECT` | `SIMPLY_XPK_PROJECT` | GCP project ID |
-| `--cluster CLUSTER` | `SIMPLY_XPK_CLUSTER` | GKE cluster name |
-| `--image IMAGE` | `SIMPLY_XPK_IMAGE` | Base Docker image |
+To preview the XPK command without submitting, add `--dry-run`.
 
 #### Common Options
 
 | Flag | Env Variable | Default | Description |
 |------|-------------|---------|-------------|
 | `--zone ZONE` | `SIMPLY_XPK_ZONE` | `us-central1` | GCP zone/region |
-| `--tpu-type TYPE` | `SIMPLY_XPK_TPU_TYPE` | `v4-8` | TPU accelerator type |
-| `--num-slices N` | `SIMPLY_XPK_NUM_SLICES` | `1` | Number of TPU slices |
-| `--priority PRI` | `SIMPLY_XPK_PRIORITY` | `medium` | Workload priority |
+| `--tpu-type TYPE` | `SIMPLY_XPK_TPU_TYPE` | `v4-8` | TPU accelerator |
+| `--num-slices N` | `SIMPLY_XPK_NUM_SLICES` | `1` | Number of slices |
+| `--priority PRI` | `SIMPLY_XPK_PRIORITY` | `medium` | Priority |
 | `--name NAME` | | auto | Custom workload name |
-| `--spot` | | (default) | Use spot/preemptible instances |
+| `--spot` | | (default) | Use spot instances |
 | `--on-demand` | | | Use on-demand instances |
-| `--dry-run` | | | Print the xpk command without running |
-
-#### Passing Simply Arguments
-
-Pass additional flags to `simply.main` after `--`:
-
-```bash
-./scripts/launch_gke.sh --config lm_test \
-    --project my-project --cluster my-cluster \
-    --image gcr.io/my-project/simply-jax-tpu:latest \
-    -- --mesh_shape 1,4,32 --experiment_dir gs://my-bucket/exp1
-```
-
-### Using Environment Variables
-
-To avoid repeating flags, set environment variables in your shell
-profile:
-
-```bash
-export SIMPLY_XPK_PROJECT=my-project
-export SIMPLY_XPK_CLUSTER=my-cluster
-export SIMPLY_XPK_ZONE=us-central1
-export SIMPLY_XPK_IMAGE=gcr.io/my-project/simply-jax-tpu:latest
-
-# Now just specify the config:
-./scripts/launch_gke.sh --config qwen3_0p6b --tpu-type v4-8
-```
+| `--dry-run` | | | Print xpk command only |
 
 ### Profiling with XProf
 
@@ -722,9 +705,9 @@ trace storage:
 ```bash
 export SIMPLY_XPK_GCS_BUCKET=gs://my-bucket/profiles
 
-./scripts/launch_gke.sh --config qwen3_0p6b --profile \
-    --project my-project --cluster my-cluster \
-    --image gcr.io/my-project/simply-jax-tpu:latest
+./scripts/launch_gke.sh --config lm_test_gke_training --profile \
+    --project $PROJECT --cluster $CLUSTER \
+    --image gcr.io/$PROJECT/simply-jax-tpu:latest
 ```
 
 This sets `JAX_PROFILER_LOG_DIR` inside the container and saves
@@ -738,24 +721,33 @@ List, monitor, and delete workloads:
 
 ```bash
 # List all simply-* workloads on the cluster
-./scripts/launch_gke.sh --list
+./scripts/launch_gke.sh \
+    --project $PROJECT --cluster $CLUSTER --zone $ZONE \
+    --list
 
 # Stream logs from a running workload
-./scripts/launch_gke.sh --logs simply-qwen3-0p6b-0310
+./scripts/launch_gke.sh \
+    --project $PROJECT --cluster $CLUSTER --zone $ZONE \
+    --logs simply-lm-test-gke-training-0311
 
 # Delete a workload
-./scripts/launch_gke.sh --delete simply-qwen3-0p6b-0310
+./scripts/launch_gke.sh \
+    --project $PROJECT --cluster $CLUSTER --zone $ZONE \
+    --delete simply-lm-test-gke-training-0311
 ```
 
-You can also use `kubectl` directly for more detailed inspection:
+You can also use `kubectl` directly for lower-level diagnostics:
 
 ```bash
-# View logs from a specific worker
-kubectl logs -l jobset.sigs.k8s.io/jobset-name=simply-qwen3-0p6b-0310 \
-    --all-containers --tail=100
+# List pods for a workload
+kubectl get pods \
+    -l "jobset.sigs.k8s.io/jobset-name=simply-lm-test-gke-training-0311"
 
-# Check pod status
-kubectl get pods -l jobset.sigs.k8s.io/jobset-name=simply-qwen3-0p6b-0310
+# Check container logs (replace POD_NAME with actual pod name)
+kubectl logs POD_NAME --all-containers 2>&1 | tail -50
+
+# Describe a pod for event details (image pull errors, scheduling)
+kubectl describe pod POD_NAME
 ```
 
 ### Docker Access
@@ -767,6 +759,40 @@ Docker is not accessible at all, run:
 ```bash
 sudo usermod -aG docker $USER && newgrp docker
 ```
+
+### GKE Troubleshooting
+
+#### Container can't find local files
+
+XPK workloads run inside containers with their own filesystem.
+Local paths like `/tmp/config.json` on your machine are not
+accessible. Upload config files and assets to GCS and use
+`gs://` paths.
+
+#### `ModuleNotFoundError` for a Python package
+
+If a package is missing in the container, add it to
+`scripts/Dockerfile.simply`, rebuild, push, and relaunch. Common
+packages that may be needed depending on your data pipeline:
+
+#### `Found incomplete checkpoint` / Orbax validation error
+
+Orbax uses `commit_success.txt` marker files to validate
+checkpoints on GCS. HuggingFace-hosted checkpoints don't include
+this file. Create it manually:
+
+```bash
+touch /tmp/commit_success.txt
+gcloud storage cp /tmp/commit_success.txt \
+    gs://$BUCKET/path/to/checkpoint/1/commit_success.txt
+```
+
+#### `FileNotFoundError: tokenizer_config.json`
+
+The launch script downloads Qwen3 tokenizer files at runtime.
+If you use a different tokenizer, you may need to add a similar
+download step to `launch_gke.sh` or pre-bake the tokenizer files
+into the Docker image.
 
 ## Future Work
 

--- a/gcloud_quickstart.md
+++ b/gcloud_quickstart.md
@@ -150,6 +150,92 @@ gcloud compute tpus tpu-vm delete $TPU_NAME \
     --zone=$ZONE --project=$PROJECT --quiet
 ```
 
+## (Optional) Running on GKE with XPK
+
+For GKE clusters with TPU node pools, you can use
+[XPK](https://github.com/AI-Hypercomputer/xpk) to launch Simply
+training workloads. This section walks through the full workflow.
+For advanced topics (details, profiling, troubleshooting), see the
+[full guide](docs/gcloud.md#11-running-on-gke-with-xpk).
+
+### Prerequisites
+
+- A GKE cluster with a TPU node pool already provisioned
+- [XPK](https://github.com/AI-Hypercomputer/xpk) installed
+  (`pip install xpk`)
+- Docker installed and authenticated to push to GCR/Artifact
+  Registry
+- `kubectl` configured for your cluster
+  (`gcloud container clusters get-credentials ...`)
+
+### Quick Commands
+
+Set these once per shell session. Replace the values with your own
+project and cluster details.
+
+```bash
+export PROJECT=your-gcp-project-id
+export CLUSTER=your-gke-cluster-name
+export ZONE=us-central1
+export TPUTYPE=tpu7x-128
+```
+
+Build the Simply base image and push it to your project's container
+registry. This image has JAX with TPU support and all Simply
+dependencies pre-installed.
+
+```bash
+cd /path/to/simply
+
+# Build the Docker image
+docker build -f scripts/Dockerfile.simply \
+    -t gcr.io/$PROJECT/simply-jax-tpu:latest .
+
+# Push to Google Container Registry
+docker push gcr.io/$PROJECT/simply-jax-tpu:latest
+```
+
+Use the launcher script to submit the workload via XPK. The
+`lm_test_gke_training` config is a small model designed for
+testing GKE training -- it uses no checkpoint and disables
+checkpoint saving, so no GCS asset upload is needed.
+
+```bash
+./scripts/launch_gke.sh \
+    --config lm_test_gke_training \
+    --project $PROJECT \
+    --cluster $CLUSTER \
+    --zone $ZONE \
+    --tpu-type $TPUTYPE \
+    --image gcr.io/$PROJECT/simply-jax-tpu:latest
+```
+
+The script packages the Simply source directory (via XPK's
+`--script-dir`), installs it inside the container, downloads the
+tokenizer, and starts training.
+
+To preview the XPK command without submitting, add `--dry-run`.
+
+To monitor and delete the workloads, you can use the following
+commands:
+
+```bash
+# List all Simply workloads on the cluster
+./scripts/launch_gke.sh \
+    --project $PROJECT --cluster $CLUSTER --zone $ZONE \
+    --list
+
+# Stream logs for a specific workload
+./scripts/launch_gke.sh \
+    --project $PROJECT --cluster $CLUSTER --zone $ZONE \
+    --logs JOB_NAME
+
+# Delete a workload when done
+./scripts/launch_gke.sh \
+    --project $PROJECT --cluster $CLUSTER --zone $ZONE \
+    --delete JOB_NAME
+```
+
 ## What Next?
 
 See the [full guide](docs/gcloud.md) for:

--- a/scripts/Dockerfile.simply
+++ b/scripts/Dockerfile.simply
@@ -1,13 +1,16 @@
 FROM python:3.12-slim
 
+# Install uv
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+
 # Install JAX with TPU support
-RUN pip install --no-cache-dir \
+RUN uv pip install --system --no-cache \
     "jax[tpu]>=0.8.2" \
     "jaxlib>=0.8.1" \
     "libtpu>=0.0.30"
 
 # Simply dependencies (from pyproject.toml)
-RUN pip install --no-cache-dir \
+RUN uv pip install --system --no-cache \
     "absl-py>=2.3.1" \
     datasets \
     deprecated \
@@ -22,6 +25,9 @@ RUN pip install --no-cache-dir \
     "wandb>=0.25.0" \
     gcsfs \
     etils \
-    huggingface_hub
+    huggingface_hub \
+    importlib_resources \
+    tensorflow-cpu \
+    tensorflow-datasets
 
 WORKDIR /app

--- a/scripts/Dockerfile.simply
+++ b/scripts/Dockerfile.simply
@@ -1,0 +1,27 @@
+FROM python:3.12-slim
+
+# Install JAX with TPU support
+RUN pip install --no-cache-dir \
+    "jax[tpu]>=0.8.2" \
+    "jaxlib>=0.8.1" \
+    "libtpu>=0.0.30"
+
+# Simply dependencies (from pyproject.toml)
+RUN pip install --no-cache-dir \
+    "absl-py>=2.3.1" \
+    datasets \
+    deprecated \
+    "einops>=0.8.1" \
+    "grain>=0.2.15" \
+    "orbax>=0.1.9" \
+    sentencepiece \
+    "setuptools<81" \
+    "tensorboard>=2.20.0" \
+    tensorboardX \
+    tokenizers \
+    "wandb>=0.25.0" \
+    gcsfs \
+    etils \
+    huggingface_hub
+
+WORKDIR /app

--- a/scripts/launch_gke.sh
+++ b/scripts/launch_gke.sh
@@ -1,0 +1,345 @@
+#!/bin/bash
+# launch_gke.sh — Launch Simply training on GKE TPU via XPK
+#
+# Usage:
+#   ./scripts/launch_gke.sh --config <CONFIG> [OPTIONS] [-- SIMPLY_ARGS...]
+#
+# Examples:
+#   # Baseline run:
+#   ./scripts/launch_gke.sh --config lm_test \
+#       --project my-project --cluster my-cluster --zone us-central1 \
+#       -- --experiment_dir gs://my-bucket/exp1
+#
+#   # With XProf profiling:
+#   ./scripts/launch_gke.sh --config lm_test --profile \
+#       --project my-project --cluster my-cluster --zone us-central1
+#
+#   # Using environment variables:
+#   export SIMPLY_XPK_PROJECT=my-project
+#   export SIMPLY_XPK_CLUSTER=my-cluster
+#   export SIMPLY_XPK_ZONE=us-central1
+#   ./scripts/launch_gke.sh --config lm_test
+#
+#   # Dry run:
+#   ./scripts/launch_gke.sh --config lm_test --dry-run
+#
+#   # List/logs/delete:
+#   ./scripts/launch_gke.sh --list
+#   ./scripts/launch_gke.sh --logs simply-lm-test-0310
+#   ./scripts/launch_gke.sh --delete simply-lm-test-0310
+
+set -euo pipefail
+
+# ------------------------------------------
+# Defaults
+# ------------------------------------------
+PROJECT="${SIMPLY_XPK_PROJECT:-}"
+CLUSTER="${SIMPLY_XPK_CLUSTER:-}"
+ZONE="${SIMPLY_XPK_ZONE:-us-central1}"
+TPU_TYPE="${SIMPLY_XPK_TPU_TYPE:-v4-8}"
+NUM_SLICES="${SIMPLY_XPK_NUM_SLICES:-1}"
+PRIORITY="${SIMPLY_XPK_PRIORITY:-medium}"
+BASE_IMAGE="${SIMPLY_XPK_IMAGE:-}"
+CAPACITY="--spot"
+
+WORKLOAD_NAME=""
+CONFIG=""
+PROFILE=false
+PROFILE_STEPS="3"
+PROFILE_WARMUP="5"
+NUM_TRAIN_STEPS=20
+SIMPLY_ARGS=""
+DRY_RUN=false
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SIMPLY_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+GCS_BUCKET="${SIMPLY_XPK_GCS_BUCKET:-}"
+
+# ------------------------------------------
+# Helper functions
+# ------------------------------------------
+usage() {
+    cat <<'USAGE'
+Usage: launch_gke.sh --config <CONFIG> [OPTIONS] [-- SIMPLY_ARGS...]
+       launch_gke.sh --list | --logs <name> | --delete <name>
+
+Launch Simply training on GKE TPU via XPK.
+
+Required:
+  --config CONFIG         Simply experiment config name (e.g., lm_test)
+  -p, --project PROJECT   GCP project (or set SIMPLY_XPK_PROJECT)
+  -c, --cluster CLUSTER   GKE cluster (or set SIMPLY_XPK_CLUSTER)
+
+Options:
+  --profile               Enable XProf trace collection
+  --profile-warmup N      Steps before profiling starts (default: 5)
+  --profile-steps N       Number of steps to profile (default: 3)
+  --train-steps N         Total training steps (default: 20)
+  -n, --name NAME         Workload name (default: auto-generated)
+  -z, --zone ZONE         GCP zone              (default: us-central1)
+  -t, --tpu-type TYPE     TPU type              (default: v4-8)
+  --num-slices N          Number of slices       (default: 1)
+  --image IMAGE           Base Docker image
+  --priority PRIORITY     Workload priority      (default: medium)
+  --spot                  Use spot instances      (default)
+  --on-demand             Use on-demand instances
+  --dry-run               Print the xpk command without running it
+
+Management:
+  --list                  List all simply-* workloads on the cluster
+  --logs NAME             Stream logs for a workload
+  --delete NAME           Delete a workload
+
+Extra simply.main args after '--':
+  e.g., -- --mesh_shape 1,8,16,1 --experiment_dir gs://bucket/exp1
+USAGE
+    exit "${1:-0}"
+}
+
+gen_name() {
+    local config_short
+    config_short="$(echo "$1" | tr '_' '-')"
+    local ts
+    ts="$(date +%m%d)"
+    local name="simply-${config_short}-${ts}"
+    echo "${name:0:40}"
+}
+
+do_list() {
+    echo "=== Listing Simply workloads on ${CLUSTER} ==="
+    xpk workload list \
+        --cluster "${CLUSTER}" \
+        --project "${PROJECT}" \
+        --zone "${ZONE}" 2>&1 \
+        | grep -E "^(Jobset|simply-|-)" || true
+}
+
+do_logs() {
+    local name="$1"
+    echo "=== Streaming logs for ${name} ==="
+    kubectl logs \
+        -l "jobset.sigs.k8s.io/jobset-name=${name}" \
+        --all-containers --follow --tail=200 2>/dev/null \
+        || echo "No logs found. The job may not have started yet."
+}
+
+do_delete() {
+    local name="$1"
+    echo "=== Deleting workload ${name} ==="
+    xpk workload delete \
+        --cluster "${CLUSTER}" \
+        --project "${PROJECT}" \
+        --zone "${ZONE}" \
+        --workload "${name}"
+}
+
+# ------------------------------------------
+# Parse arguments
+# ------------------------------------------
+ACTION="launch"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --list)
+            ACTION="list"; shift ;;
+        --logs)
+            ACTION="logs"; WORKLOAD_NAME="$2"; shift 2 ;;
+        --delete)
+            ACTION="delete"; WORKLOAD_NAME="$2"; shift 2 ;;
+        --config)
+            CONFIG="$2"; shift 2 ;;
+        --profile)
+            PROFILE=true; shift ;;
+        --profile-warmup)
+            PROFILE_WARMUP="$2"; shift 2 ;;
+        --profile-steps)
+            PROFILE_STEPS="$2"; shift 2 ;;
+        --train-steps)
+            NUM_TRAIN_STEPS="$2"; shift 2 ;;
+        -n|--name)
+            WORKLOAD_NAME="$2"; shift 2 ;;
+        -c|--cluster)
+            CLUSTER="$2"; shift 2 ;;
+        -p|--project)
+            PROJECT="$2"; shift 2 ;;
+        -z|--zone)
+            ZONE="$2"; shift 2 ;;
+        -t|--tpu-type)
+            TPU_TYPE="$2"; shift 2 ;;
+        --num-slices)
+            NUM_SLICES="$2"; shift 2 ;;
+        --image)
+            BASE_IMAGE="$2"; shift 2 ;;
+        --priority)
+            PRIORITY="$2"; shift 2 ;;
+        --spot)
+            CAPACITY="--spot"; shift ;;
+        --on-demand)
+            CAPACITY="--on-demand"; shift ;;
+        --dry-run)
+            DRY_RUN=true; shift ;;
+        -h|--help)
+            usage 0 ;;
+        --)
+            shift; SIMPLY_ARGS="$*"; break ;;
+        -*)
+            echo "Error: Unknown option: $1" >&2; usage 1 ;;
+        *)
+            echo "Error: Unexpected argument: $1" >&2; usage 1 ;;
+    esac
+done
+
+# ------------------------------------------
+# Handle management actions
+# ------------------------------------------
+case "${ACTION}" in
+    list)   do_list; exit 0 ;;
+    logs)   do_logs "${WORKLOAD_NAME}"; exit 0 ;;
+    delete) do_delete "${WORKLOAD_NAME}"; exit 0 ;;
+esac
+
+# ------------------------------------------
+# Validate inputs for launch
+# ------------------------------------------
+if [ -z "${CONFIG}" ]; then
+    echo "Error: --config is required." >&2
+    usage 1
+fi
+
+if [ -z "${PROJECT}" ]; then
+    echo "Error: --project (or SIMPLY_XPK_PROJECT) is required." >&2
+    usage 1
+fi
+
+if [ -z "${CLUSTER}" ]; then
+    echo "Error: --cluster (or SIMPLY_XPK_CLUSTER) is required." >&2
+    usage 1
+fi
+
+if [ -z "${BASE_IMAGE}" ]; then
+    echo "Error: --image (or SIMPLY_XPK_IMAGE) is required." >&2
+    echo "Build one with: docker build" \
+        "-f scripts/Dockerfile.simply -t <tag> ." >&2
+    exit 1
+fi
+
+# Generate workload name if not provided
+if [ -z "${WORKLOAD_NAME}" ]; then
+    WORKLOAD_NAME="$(gen_name "${CONFIG}")"
+fi
+
+# ------------------------------------------
+# Build the Simply command
+# ------------------------------------------
+INSTALL_CMD="pip install --no-cache-dir . 2>/dev/null"
+
+SIMPLY_CMD="python3 -u -m simply.main"
+SIMPLY_CMD="${SIMPLY_CMD} --experiment_config=${CONFIG}"
+SIMPLY_CMD="${SIMPLY_CMD} --alsologtostderr"
+
+if [ -n "${SIMPLY_ARGS}" ]; then
+    SIMPLY_CMD="${SIMPLY_CMD} ${SIMPLY_ARGS}"
+fi
+
+if [ "${PROFILE}" = true ] && [ -n "${GCS_BUCKET}" ]; then
+    PROFILE_DIR="${GCS_BUCKET}/${WORKLOAD_NAME}"
+    LOG_SAVE="gsutil cp /tmp/simply_output.log"
+    LOG_SAVE="${LOG_SAVE} ${PROFILE_DIR}/worker-\$(hostname).log"
+    LOG_SAVE="${LOG_SAVE} 2>/dev/null || true"
+    PROFILE_ENV="JAX_PROFILER_LOG_DIR=${PROFILE_DIR}"
+    PROFILE_ENV="${PROFILE_ENV} SIMPLY_PROFILE_START_STEP=${PROFILE_WARMUP}"
+    PROFILE_ENV="${PROFILE_ENV} SIMPLY_PROFILE_END_STEP=$((PROFILE_WARMUP + PROFILE_STEPS))"
+    FULL_CMD="${INSTALL_CMD} && (${PROFILE_ENV} ${SIMPLY_CMD}"
+    FULL_CMD="${FULL_CMD} 2>&1 | tee /tmp/simply_output.log;"
+    FULL_CMD="${FULL_CMD} ${LOG_SAVE})"
+elif [ "${PROFILE}" = true ]; then
+    echo "Warning: --profile requires SIMPLY_XPK_GCS_BUCKET." \
+        "Profiling disabled." >&2
+    FULL_CMD="${INSTALL_CMD} && ${SIMPLY_CMD}"
+else
+    FULL_CMD="${INSTALL_CMD} && ${SIMPLY_CMD}"
+fi
+
+# ------------------------------------------
+# Launch
+# ------------------------------------------
+echo "============================================"
+echo "  Simply — XPK Training Launch"
+echo "============================================"
+echo "  Workload:  ${WORKLOAD_NAME}"
+echo "  Config:    ${CONFIG}"
+echo "  Cluster:   ${CLUSTER}"
+echo "  Project:   ${PROJECT}"
+echo "  Zone:      ${ZONE}"
+echo "  TPU Type:  ${TPU_TYPE}"
+echo "  Slices:    ${NUM_SLICES}"
+echo "  Priority:  ${PRIORITY}"
+echo "  Capacity:  ${CAPACITY/--/}"
+echo "  Image:     ${BASE_IMAGE}"
+echo "  Profile:   ${PROFILE}"
+if [ "${PROFILE}" = true ] && [ -n "${GCS_BUCKET}" ]; then
+echo "  Prof Dir:  ${PROFILE_DIR}"
+fi
+echo "  Simply:    ${SIMPLY_DIR}"
+echo "  Command:   ${SIMPLY_CMD}"
+echo "============================================"
+
+XPK_CMD=(
+    xpk workload create
+    --cluster "${CLUSTER}"
+    --project "${PROJECT}"
+    --zone "${ZONE}"
+    --workload "${WORKLOAD_NAME}"
+    --base-docker-image "${BASE_IMAGE}"
+    --script-dir "${SIMPLY_DIR}"
+    --tpu-type="${TPU_TYPE}"
+    --num-slices="${NUM_SLICES}"
+    --priority="${PRIORITY}"
+    "${CAPACITY}"
+    --command "${FULL_CMD}"
+)
+
+if [ "${DRY_RUN}" = true ]; then
+    echo ""
+    echo "[DRY RUN] Would execute:"
+    echo "  xpk workload create \\"
+    echo "    --cluster ${CLUSTER} \\"
+    echo "    --project ${PROJECT} \\"
+    echo "    --zone ${ZONE} \\"
+    echo "    --workload ${WORKLOAD_NAME} \\"
+    echo "    --base-docker-image ${BASE_IMAGE} \\"
+    echo "    --script-dir ${SIMPLY_DIR} \\"
+    echo "    --tpu-type=${TPU_TYPE} \\"
+    echo "    --num-slices=${NUM_SLICES} \\"
+    echo "    --priority=${PRIORITY} \\"
+    echo "    ${CAPACITY} \\"
+    echo "    --command \"${FULL_CMD}\""
+    echo ""
+    exit 0
+fi
+
+echo ""
+echo "=== Submitting workload ==="
+
+if docker info &>/dev/null; then
+    "${XPK_CMD[@]}"
+elif sg docker -c "docker info" &>/dev/null; then
+    echo "(Using 'sg docker' for Docker access)"
+    sg docker -c "$(printf '%q ' "${XPK_CMD[@]}")"
+else
+    echo "Error: Docker is not accessible." >&2
+    echo "  sudo usermod -aG docker \$USER && newgrp docker" >&2
+    exit 1
+fi
+
+echo ""
+echo "============================================"
+echo "  Workload submitted: ${WORKLOAD_NAME}"
+echo "============================================"
+echo ""
+echo "Monitor:"
+echo "  ./scripts/launch_gke.sh --list"
+echo "  ./scripts/launch_gke.sh --logs ${WORKLOAD_NAME}"
+echo ""
+echo "Cleanup:"
+echo "  ./scripts/launch_gke.sh --delete ${WORKLOAD_NAME}"

--- a/scripts/launch_gke.sh
+++ b/scripts/launch_gke.sh
@@ -120,7 +120,10 @@ do_logs() {
     kubectl logs \
         -l "jobset.sigs.k8s.io/jobset-name=${name}" \
         --all-containers --follow --tail=200 2>/dev/null \
-        || echo "No logs found. The job may not have started yet."
+    || kubectl logs \
+        -l "jobset.sigs.k8s.io/jobset-name=${name}" \
+        --all-containers --tail=200 2>/dev/null \
+    || echo "No logs found. The job may not have started yet."
 }
 
 do_delete() {
@@ -231,7 +234,12 @@ fi
 # ------------------------------------------
 # Build the Simply command
 # ------------------------------------------
-INSTALL_CMD="pip install --no-cache-dir . 2>/dev/null"
+INSTALL_CMD="uv pip install --system --no-cache . 2>/dev/null"
+
+# Download vocab/tokenizer files that Simply needs at runtime.
+# Qwen3 tokenizer is fetched from HuggingFace into the default
+# vocabs directory (~/.cache/simply/vocabs/Qwen3/).
+VOCAB_SETUP="python3 -c \"import os; from huggingface_hub import hf_hub_download; d=os.path.expanduser('~/.cache/simply/vocabs/Qwen3'); os.makedirs(d,exist_ok=True); [hf_hub_download('Qwen/Qwen3-0.6B',f,local_dir=d) for f in ['tokenizer.json','tokenizer_config.json']]\""
 
 SIMPLY_CMD="python3 -u -m simply.main"
 SIMPLY_CMD="${SIMPLY_CMD} --experiment_config=${CONFIG}"
@@ -249,15 +257,16 @@ if [ "${PROFILE}" = true ] && [ -n "${GCS_BUCKET}" ]; then
     PROFILE_ENV="JAX_PROFILER_LOG_DIR=${PROFILE_DIR}"
     PROFILE_ENV="${PROFILE_ENV} SIMPLY_PROFILE_START_STEP=${PROFILE_WARMUP}"
     PROFILE_ENV="${PROFILE_ENV} SIMPLY_PROFILE_END_STEP=$((PROFILE_WARMUP + PROFILE_STEPS))"
-    FULL_CMD="${INSTALL_CMD} && (${PROFILE_ENV} ${SIMPLY_CMD}"
+    FULL_CMD="${INSTALL_CMD} && ${VOCAB_SETUP}"
+    FULL_CMD="${FULL_CMD} && (${PROFILE_ENV} ${SIMPLY_CMD}"
     FULL_CMD="${FULL_CMD} 2>&1 | tee /tmp/simply_output.log;"
     FULL_CMD="${FULL_CMD} ${LOG_SAVE})"
 elif [ "${PROFILE}" = true ]; then
     echo "Warning: --profile requires SIMPLY_XPK_GCS_BUCKET." \
         "Profiling disabled." >&2
-    FULL_CMD="${INSTALL_CMD} && ${SIMPLY_CMD}"
+    FULL_CMD="${INSTALL_CMD} && ${VOCAB_SETUP} && ${SIMPLY_CMD}"
 else
-    FULL_CMD="${INSTALL_CMD} && ${SIMPLY_CMD}"
+    FULL_CMD="${INSTALL_CMD} && ${VOCAB_SETUP} && ${SIMPLY_CMD}"
 fi
 
 # ------------------------------------------
@@ -338,8 +347,8 @@ echo "  Workload submitted: ${WORKLOAD_NAME}"
 echo "============================================"
 echo ""
 echo "Monitor:"
-echo "  ./scripts/launch_gke.sh --list"
-echo "  ./scripts/launch_gke.sh --logs ${WORKLOAD_NAME}"
+echo "  ./scripts/launch_gke.sh --project $PROJECT --cluster $CLUSTER --zone $ZONE --list"
+echo "  ./scripts/launch_gke.sh --project $PROJECT --cluster $CLUSTER --zone $ZONE --logs ${WORKLOAD_NAME}"
 echo ""
 echo "Cleanup:"
-echo "  ./scripts/launch_gke.sh --delete ${WORKLOAD_NAME}"
+echo "  ./scripts/launch_gke.sh --project $PROJECT --cluster $CLUSTER --zone $ZONE --delete ${WORKLOAD_NAME}"

--- a/simply/config_lib.py
+++ b/simply/config_lib.py
@@ -1914,6 +1914,16 @@ def lm_test():
       tb_log_interval=2,
   )
 
+@ExperimentConfigRegistry.register
+def lm_test_gke_training() -> BaseExperimentConfig:
+  """Synthetic config for testing GKE training."""
+  return dataclasses.replace(
+      lm_test(),
+      init_ckpt_dir='',
+      batch_size=128,
+      should_save_ckpt=False,
+      gmm_impl='ragged_dot',
+  )
 
 @ExperimentConfigRegistry.register
 def lm_no_scan_test():


### PR DESCRIPTION
Adds scripts to launch Simply training jobs on GKE TPU clusters xpk.
  - scripts/launch_gke.sh — wrapper around xpk workload create with support for launching, listing, streaming logs, and deleting workloads
  - scripts/Dockerfile.simply — base Docker image with JAX TPU support and Simply dependencies pre-installed
  - Updated README.md and docs/gcloud.md with GKE usage instructions
 

Usage
```bash
  ./scripts/launch_gke.sh --config qwen3_0p6b \
      --project my-project --cluster my-cluster \
      --tpu-type v4-8 --image gcr.io/my-project/simply-jax-tpu:latest
```
All required flags can also be set via SIMPLY_XPK_* environment variables. Run `./scripts/launch_gke.sh --help` for the full list of options.

Tested on a tpu7x-128 GKE cluster. The script successfully builds and pushes Docker images, submits workloads via XPK.

