### PR TITLE
Fix duplicate tensorflow-datasets entry in uv.lock

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2705,7 +2705,6 @@ dependencies = [
     { name = "setuptools" },
     { name = "tensorboard" },
     { name = "tensorboardx" },
-    { name = "tensorflow-datasets" },
     { name = "tokenizers" },
     { name = "wandb" },
 ]
@@ -2754,8 +2753,7 @@ requires-dist = [
     { name = "tensorboardx" },
     { name = "tensorflow", marker = "sys_platform == 'darwin' and extra == 'tfds'" },
     { name = "tensorflow-cpu", marker = "sys_platform != 'darwin' and extra == 'tfds'" },
-    { name = "tensorflow-datasets", specifier = ">=4.9.9" },
-    { name = "tensorflow-datasets", marker = "extra == 'tfds'" },
+    { name = "tensorflow-datasets", marker = "extra == 'tfds'", specifier = ">=4.9.9" },
     { name = "tokenizers" },
     { name = "wandb", specifier = ">=0.25.0" },
 ]


### PR DESCRIPTION
The requires-dist section listed tensorflow-datasets twice (an unconditional >=4.9.9 entry and a separate extra=="tfds" entry). Collapsed into a single { marker = "extra == 'tfds'", specifier = ">=4.9.9" } entry.