### PR TITLE
Handle disabled Bash action timeouts

### DIFF
--- a/simply/agent/tools.py
+++ b/simply/agent/tools.py
@@ -133,7 +133,8 @@ class BashAction(Action):
 
   def to_llm(self) -> str:
     """Returns the string representation of the action for LLM consumption."""
-    return f'COMMAND:\n{self.command}\nTIMEOUT: {self.timeout:.2f}'
+    timeout = 'None' if self.timeout is None else f'{self.timeout:.2f}'
+    return f'COMMAND:\n{self.command}\nTIMEOUT: {timeout}'
 
   @classmethod
   def format_output(

--- a/simply/agent/tools_test.py
+++ b/simply/agent/tools_test.py
@@ -22,6 +22,33 @@ from simply.agent import tools
 
 class BashToolTest(absltest.TestCase):
 
+  def test_execute_without_timeout(self):
+    tool = tools.BashTool(executor=env.execute_bash_locally)
+    with mock.patch.object(subprocess, 'run') as mock_run:
+      mock_run.return_value.stdout = ''
+      mock_run.return_value.stderr = ''
+      mock_run.return_value.returncode = 0
+
+      action, observation = tool.execute(
+          args_json='{"command": "sleep 10", "timeout": null}'
+      )
+
+    self.assertIsNotNone(action)
+    self.assertEqual(action.to_llm(), 'COMMAND:\nsleep 10\nTIMEOUT: None')
+    self.assertIn('RETURN CODE: 0', observation)
+    self.assertIsNone(action.timeout)
+    mock_run.assert_called_once_with(
+        'sleep 10',
+        shell=True,
+        check=False,
+        text=True,
+        encoding='utf-8',
+        errors='backslashreplace',
+        capture_output=True,
+        timeout=None,
+        cwd=None,
+    )
+
   def test_execute_success(self):
     tool = tools.BashTool(executor=env.execute_bash_locally)
     with mock.patch.object(subprocess, 'run') as mock_run:


### PR DESCRIPTION
## Summary

Serialize `BashAction(timeout=None)` without applying float formatting to `None`.

The schema permits a null timeout and execution passes it to `subprocess.run` to disable the limit, but `to_llm()` raised `TypeError` afterward. The representation now emits `TIMEOUT: None` for that supported case.

## Tests

- Added a JSON `null` timeout test through the real tool execution path
- Verified successful execution and LLM serialization
