### PR TITLE
Fix empty nucleus when top_p is zero

### DIFF
--- a/simply/utils/sampling_lib.py
+++ b/simply/utils/sampling_lib.py
@@ -432,11 +432,16 @@ def top_k_mask(logits: jax.Array, top_k: int) -> jax.Array:
 
 
 def top_p_mask(logits: jax.Array, top_p: float) -> jax.Array:
+  """Masks logits outside the nucleus, always keeping its top token."""
   probs = jax.nn.softmax(logits, axis=-1)
   indices = jnp.argsort(logits, axis=-1, descending=True)
   sorted_probs = jnp.take_along_axis(probs, indices, axis=-1)
   cumsum = jnp.cumulative_sum(sorted_probs, axis=-1, include_initial=True)
   mask = cumsum[..., :-1] < top_p
+  # A nucleus must contain at least one candidate. In particular, top_p=0
+  # should reduce to the highest-logit token instead of producing an empty
+  # mask whose fallback logits can select an unrelated vocabulary item.
+  mask = mask.at[..., 0].set(True)
   _, mask = jax.lax.sort_key_val(indices, mask, dimension=-1)
   return mask
 
@@ -456,7 +461,8 @@ def _fused_top_k_top_p_mask(
     top_p: Cumulative probability threshold within the top-k candidates.
 
   Returns:
-    Boolean mask of shape ``logits.shape``.
+    Boolean mask of shape ``logits.shape`` containing at least the
+    highest-logit token.
   """
   vocab_size = logits.shape[-1]
   k = max(min(top_k, vocab_size), 1)
@@ -465,6 +471,7 @@ def _fused_top_k_top_p_mask(
   probs = jax.nn.softmax(top_k_vals, axis=-1)
   cumsum = jnp.cumulative_sum(probs, axis=-1, include_initial=True)
   top_p_keep = cumsum[..., :-1] < top_p
+  top_p_keep = top_p_keep.at[..., 0].set(True)
   indicator = jax.nn.one_hot(top_k_indices, vocab_size, dtype=jnp.bool_)
   return jnp.any(indicator & top_p_keep[..., None], axis=-2)
 

--- a/simply/utils/sampling_lib_test.py
+++ b/simply/utils/sampling_lib_test.py
@@ -126,6 +126,7 @@ class SamplingLibTest(parameterized.TestCase):
     mask = sampling_lib.top_p_mask(logits, top_p=top_p)
     self.assertEqual(mask.shape, logits.shape)
     self.assertEqual(mask.dtype, jnp.bool)
+    self.assertTrue(jnp.all(jnp.sum(mask, axis=-1) >= 1))
     np.testing.assert_array_less(
         top_p, jnp.sum(probs, axis=-1, initial=0, where=mask) + 1e-6
     )
@@ -134,6 +135,47 @@ class SamplingLibTest(parameterized.TestCase):
         jnp.max(logits, axis=-1, initial=jnp.finfo(dtype).min, where=~mask),
         jnp.min(logits, axis=-1, initial=jnp.finfo(dtype).max, where=mask),
     )
+
+  def test_top_p_zero_masks_only_argmax(self):
+    logits = jnp.array([
+        [-20.0, -10.0, 10.0, 0.0],
+        [1.0, 3.0, -1.0, 2.0],
+    ])
+    expected = jax.nn.one_hot(
+        jnp.argmax(logits, axis=-1), logits.shape[-1], dtype=jnp.bool_
+    )
+
+    np.testing.assert_array_equal(
+        sampling_lib.top_p_mask(logits, top_p=0.0), expected
+    )
+    np.testing.assert_array_equal(
+        sampling_lib._fused_top_k_top_p_mask(
+            logits, top_k=2, top_p=0.0
+        ),
+        expected,
+    )
+
+  @parameterized.named_parameters(
+      ('top_p_only', -1),
+      ('fused_top_k_top_p', 2),
+  )
+  def test_top_p_zero_samples_and_scores_argmax(self, top_k: int):
+    logits = jnp.array([
+        [-20.0, -10.0, 10.0, 0.0],
+        [1.0, 3.0, -1.0, 2.0],
+    ])
+    expected_tokens = jnp.argmax(logits, axis=-1)
+
+    tokens, logprobs = sampling_lib.sample_from_logits(
+        jax.random.key(0), logits, top_k=top_k, top_p=0.0
+    )
+    scores = sampling_lib.compute_log_likelihood(
+        logits, tokens, top_k=top_k, top_p=0.0
+    )
+
+    np.testing.assert_array_equal(tokens, expected_tokens)
+    np.testing.assert_array_equal(logprobs, jnp.zeros_like(logprobs))
+    np.testing.assert_array_equal(scores, logprobs)
 
   def test_sample_from_logits(self):
     logits = jax.random.normal(jax.random.key(0), (5, 3, 10))


### PR DESCRIPTION
## What changed

This fixes a bug where `top_p=0` created an empty candidate mask.

I updated both normal top-p sampling and fused top-k/top-p sampling so they always keep the highest-logit token. With `top_p=0`, sampling now behaves like greedy decoding instead of potentially returning an unrelated token.

I also added regression tests for:

- nonempty candidate masks
- correct argmax selection
- staying inside the requested top-k set
- matching sampling and scoring results

## Why

Before this change, both mask implementations returned all `False` for `top_p=0`. The fallback logits could then select token 0 even when it was not the argmax or part of the top-k set.

Positive `top_p` behavior is unchanged.

## Testing

- `pytest simply/utils/sampling_lib_test.py -p no:cacheprovider -q`: 43 passed
- broader CPU-compatible suite: 264 passed, 22 hardware-dependent skips
- `git diff --check`